### PR TITLE
h-refinement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,19 +83,19 @@ jobs:
 
     - name: 'ethier build-only'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R "^ethier-buildOnly$"
+      run: ctest --output-on-failure -R "^ethier-buildOnly_*[0-9]$"
 
     - name: 'ethier'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R "^ethier$"
+      run: ctest --output-on-failure -R "^ethier_*[0-9]$"
 
     - name: 'ethierRefine build-only'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R ethierRefine-buildOnly
+      run: ctest --output-on-failure -R "^ethierRefine-buildOnly_*[0-9]$"
 
     - name: 'ethierRefine'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R ethierRefine
+      run: ctest --output-on-failure -R "^ethierRefine_*[0-9]$"
 
   lowMach:
     needs: install
@@ -149,7 +149,7 @@ jobs:
 
     - name: 'mv_cyl'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R "^mv_cyl$"
+      run: ctest --output-on-failure -R "^mv_cyl_*[0-9]$"
 
     - name: 'mv_cyl_derived_bc'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,19 @@ jobs:
 
     - name: 'ethier build-only'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R ethier-buildOnly 
+      run: ctest --output-on-failure -R "^ethier-buildOnly$"
 
     - name: 'ethier'
       working-directory: ${{ env.NEKRS_EXAMPLES }}/build
-      run: ctest --output-on-failure -R ethier 
+      run: ctest --output-on-failure -R "^ethier$"
+
+    - name: 'ethierRefine build-only'
+      working-directory: ${{ env.NEKRS_EXAMPLES }}/build
+      run: ctest --output-on-failure -R ethierRefine-buildOnly
+
+    - name: 'ethierRefine'
+      working-directory: ${{ env.NEKRS_EXAMPLES }}/build
+      run: ctest --output-on-failure -R ethierRefine
 
   lowMach:
     needs: install

--- a/3rd_party/nek5000/core/ic.f
+++ b/3rd_party/nek5000/core/ic.f
@@ -2526,6 +2526,7 @@ c
      $                        commrs,rsH,ierr)
 
           if (ierr .ne. 0 ) call exitti('MPI_Win_allocate failed!$',0)
+          call rzero(wk,lwk) ! avoid un-initialized values
         endif
       endif
 #endif

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -111,6 +111,9 @@ add("ethier" 2 "mv_ethier.par" "5;6" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
 add("ethier" 2 "ethierScalar.par" "13" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
 add("ethier" 2 "ethier.par" "22" ON "${dir}" "${BUILD_ONLY}")
 
+add("ethierRefine-buildOnly" 2 "ethierRefine.par" "24" "${USE_FP32}" "${EXAMPLES_DIR}/ethier" ON)
+add("ethierRefine" 2 "ethierRefine.par" "24;25;26;27" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
+
 add("lowMach" 2 "lowMach.par" "1" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
 
 add("mv_cyl" 2 "mv_cyl.par" "1;2;3;5;6" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -112,7 +112,7 @@ add("ethier" 2 "ethierScalar.par" "13" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
 add("ethier" 2 "ethier.par" "22" ON "${dir}" "${BUILD_ONLY}")
 
 add("ethierRefine-buildOnly" 2 "ethierRefine.par" "24" "${USE_FP32}" "${EXAMPLES_DIR}/ethier" ON)
-add("ethierRefine" 2 "ethierRefine.par" "24;25;26;27" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
+add("ethierRefine" 2 "ethierRefine.par" "24;25;26;27" "${USE_FP32}" "${EXAMPLES_DIR}/ethier" "${BUILD_ONLY}")
 
 add("lowMach" 2 "lowMach.par" "1" "${USE_FP32}" "${dir}" "${BUILD_ONLY}")
 

--- a/examples/ethier/ci.inc
+++ b/examples/ethier/ci.inc
@@ -323,11 +323,7 @@ void ciSetup(MPI_Comm comm, setupAide &options)
     options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
   }
 
-  // refine
-  if (ciMode == 24) {
-    options.setArgs("MESH REFINEMENT SCHEDULE", "2,2");
-    options.setArgs("DT", std::string("5e-4"));
-    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+  if (ciMode == 24 || ciMode == 25 || ciMode == 26 || ciMode == 27) {
     std::string casename = platform->options.getArgs("CASENAME");
     nekrsCheck(casename != "ethierRefine",
                platform->comm.mpiComm,
@@ -335,20 +331,65 @@ void ciSetup(MPI_Comm comm, setupAide &options)
                "Unexpected input file for CI mode %d\n",
                ciMode);
   }
-  // refine + checkpoint
-  if (ciMode == 25) {
-    //options.setArgs("MESH REFINEMENT SCHEDULE", "2,2"); // TODO
-//    options.setArgs("MESH REFINEMENT SCHEDULE", "4");
-//    options.setArgs("POLYNOMIAL DEGREE", std::string("10")); //TODO
+
+  // refine = 2
+  if (ciMode == 24) {
     options.setArgs("MESH REFINEMENT SCHEDULE", "2");
+    options.setArgs("MESH REFINEMENT NCUT", "2");
+    options.setArgs("MESH REFINEMENT SCALE", "8"); // 8x mesh size
+    options.setArgs("DT", std::string("1e-3"));
+    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+  }
+
+  // refine = 2,2
+  if (ciMode == 25) {
+    options.setArgs("MESH REFINEMENT SCHEDULE", "2,2");
+    options.setArgs("MESH REFINEMENT NCUT", "4"); // = 2 x 2
+    options.setArgs("MESH REFINEMENT SCALE", "64"); // 64x mesh size
+    options.setArgs("DT", std::string("5e-4"));
+    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+  }
+
+  // refine = 2 + checkpoint
+  if (ciMode == 26) {
+    options.setArgs("MESH REFINEMENT SCHEDULE", "2");
+    options.setArgs("MESH REFINEMENT NCUT", "2");
+    options.setArgs("MESH REFINEMENT SCALE", "8");
     options.setArgs("NUMBER TIMESTEPS", std::string("0"));
     options.setArgs("END TIME", std::string("0"));
     options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
-    std::string casename = platform->options.getArgs("CASENAME");
-    nekrsCheck(casename != "ethierRefine",
+
+    std::string fname = "ci23.fld";
+    nekrsCheck(!fs::exists(fname),
                platform->comm.mpiComm,
                EXIT_FAILURE,
-               "Unexpected input file for CI mode %d\n",
+               "Missing checkpoint file %s for CI mode %d, Run cimode=23 first\n",
+               fname.c_str(),
+               ciMode);
+  }
+  // refine = 2,2 + checkpoint
+  if (ciMode == 27) {
+    options.setArgs("MESH REFINEMENT SCHEDULE", "2,2");
+    options.setArgs("MESH REFINEMENT NCUT", "4");
+    options.setArgs("MESH REFINEMENT SCALE", "64");
+    options.setArgs("NUMBER TIMESTEPS", std::string("0"));
+    options.setArgs("END TIME", std::string("0"));
+    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+
+    std::string fname = "ci23.fld";
+    nekrsCheck(!fs::exists(fname),
+               platform->comm.mpiComm,
+               EXIT_FAILURE,
+               "Missing checkpoint file %s for CI mode %d, Run cimode=23 first\n",
+               fname.c_str(),
+               ciMode);
+
+    fname = "ci26.fld";
+    nekrsCheck(!fs::exists(fname),
+               platform->comm.mpiComm,
+               EXIT_FAILURE,
+               "Missing checkpoint file %s for CI mode %d, Run cimode=26 first\n",
+               fname.c_str(),
                ciMode);
   }
 }
@@ -761,10 +802,9 @@ void ciCheckpointing(nrs_t *nrs)
 {
   auto run = [&](const std::string &tag, const std::string& engine, const std::string& restartFile, bool readOnly = false)
   {
-    auto FP64 = platform->options.compareArgs("CHECKPOINT PRECISION", "FP64");
+    auto FP64 = (!readOnly) && platform->options.compareArgs("CHECKPOINT PRECISION", "FP64");
     const auto tol = (FP64) ? 10 * std::numeric_limits<double>::epsilon() : 10 * std::numeric_limits<float>::epsilon();
     const double time = 0.123; // just for testing, actual solution is based on t==0
-
     if (!readOnly) {
       platform->options.setArgs("CHECKPOINT ENGINE", engine);
       nrs->checkpointWriter = iofldFactory::create();
@@ -831,20 +871,36 @@ void ciCheckpointing(nrs_t *nrs)
 
     run("7", "ADIOS", "ethier.bp");
     run("8", "ADIOS", "ethier.bp+int", true);
+
+    MPI_Barrier(platform->comm.mpiComm);
+    if (platform->comm.mpiRank == 0) {
+      std::rename("ethier0.f00000", "ci23.fld"); // for cimode = 26, 27
+    }
+    MPI_Barrier(platform->comm.mpiComm);
   }
 
-  if (ciMode==25) {
-    platform->options.setArgs("MESH REFINEMENT SCHEDULE", "0"); // TODO
+  if (ciMode==26) { // ref = 2
     run("1", "NEK", "ethierRefine0.f00000");
-    //platform->options.setArgs("MESH REFINEMENT SCHEDULE", "0");
-    //run("NEK", "ref22.fld",true);
-    platform->options.setArgs("MESH REFINEMENT SCHEDULE", "2");
-    run("2", "NEK", "ref0.fld+U+P+S",true);
-    breakMesh(); // force loading mesh from restart
-    run("3", "NEK", "ref0.fld",true); // TODO multi file
-
-    platform->options.setArgs("MESH REFINEMENT SCHEDULE", "0"); // TODO
+    run("2", "NEK", "ci23.fld+U+P+S+refine=2",true);
+    breakMesh();
+    run("3", "NEK", "ethierRefine0.f00000+X,ci23.fld+refine=2+U+P+S",true);
     run("4", "NEK", "ethierRefine0.f00001");
+    run("5", "ADIOS", "ethierRefine.bp");
+
+    MPI_Barrier(platform->comm.mpiComm);
+    if (platform->comm.mpiRank == 0) {
+      std::rename("ethierRefine0.f00000", "ci26.fld"); // for cimode = 27
+    }
+    MPI_Barrier(platform->comm.mpiComm);
+  }
+
+  if (ciMode==27) { // refine = 2,2
+    run("1", "NEK", "ethierRefine0.f00000");
+    run("2", "NEK", "ci23.fld+U+P+S+refine=2;2",true);
+    breakMesh();
+    run("3", "NEK", "ethierRefine0.f00000+X,ci23.fld+U+refine=2;2,ci26.fld+P+S+refine=2",true);
+    run("4", "NEK", "ethierRefine0.f00001");
+    run("5", "ADIOS", "ethierRefine.bp");
   }
 }
 
@@ -1034,10 +1090,6 @@ void ciTestErrors(nrs_t *nrs,
                   occa::kernel exactUVWPKernel,
                   occa::kernel RKKernel)
 {
-  if (std::fetestexcept(FE_INVALID)) {
-    throw std::runtime_error("floating-point exception occured!");
-  }  
-
   const int rank = platform->comm.mpiRank;
 
   if (ciMode == 15) {
@@ -1064,7 +1116,8 @@ void ciTestErrors(nrs_t *nrs,
     return; // don't run the rest of the tests
   }
 
-  if (tstep == 1 && ciMode != 7 && ciMode != 13 && ciMode != 8 && ciMode != 24) { // TODO
+  if (tstep == 1 && ciMode != 7 && ciMode != 13 && ciMode != 8 &&
+      ciMode != 24 && ciMode != 25 && ciMode != 26 && ciMode != 27) {
     const auto NiterP = nrs->pSolver->Niter();
 
     int expectedNiterP = 7; 
@@ -1458,13 +1511,14 @@ void ciTestErrors(nrs_t *nrs,
     break;
   }
   case 24:
+  case 25:
   {
-    velIterTest = true; //abs(NiterU - 14) < 2; // TODO
-    s1Test = abs((err[2] - 5.42E-12) / err[2]) < EPS;
-    s2Test = abs((err[3] - 6.30E-12) / err[3]) < EPS;
-    pIterTest = true; //abs(NiterP - 6) < 2;
-    vxTest = abs((err[0] - 2.77E-10) / err[0]) < EPS;
-    prTest = abs((err[1] - 7.14E-10) / err[1]) < EPS;
+    velIterTest < 30;
+    s1Test = err[2] < 5.42E-12;
+    s2Test = err[3] < 6.30E-12;
+    pIterTest = NiterP < 10;
+    vxTest = err[0] < 2.77E-10;
+    prTest = err[1] < 7.14E-10;
     break;
   }
  

--- a/examples/ethier/ci.inc
+++ b/examples/ethier/ci.inc
@@ -320,6 +320,33 @@ void ciSetup(MPI_Comm comm, setupAide &options)
     options.setArgs("END TIME", std::string("0"));
     options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
   }
+
+  // refine
+  if (ciMode == 24) {
+    options.setArgs("MESH REFINEMENT SCHEDULE", "2,2");
+    options.setArgs("DT", std::string("5e-4"));
+    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+    std::string casename = platform->options.getArgs("CASENAME");
+    nekrsCheck(casename != "ethierRefine",
+               platform->comm.mpiComm,
+               EXIT_FAILURE,
+               "Unexpected input file for CI mode %d\n",
+               ciMode);
+  }
+  // refine + checkpoint
+  if (ciMode == 25) {
+    //options.setArgs("MESH REFINEMENT SCHEDULE", "2,2"); // TODO
+    options.setArgs("MESH REFINEMENT SCHEDULE", "4");
+    options.setArgs("NUMBER TIMESTEPS", std::string("0"));
+    options.setArgs("END TIME", std::string("0"));
+    options.setArgs("CHECKPOINT INTERVAL", std::string("0"));
+    std::string casename = platform->options.getArgs("CASENAME");
+    nekrsCheck(casename != "ethierRefine",
+               platform->comm.mpiComm,
+               EXIT_FAILURE,
+               "Unexpected input file for CI mode %d\n",
+               ciMode);
+  }
 }
 
 auto generatePoints(int nPoints, double R)
@@ -740,12 +767,18 @@ void ciCheckpointing(nrs_t *nrs)
       nrs->writeCheckpoint(time, 0);
     }
 
+    // wipe out solutions
+    platform->linAlg->fill(nrs->NVfields * nrs->fieldOffset, 0.0, nrs->o_U);
+    if (nrs->Nscalar > 0) {
+      platform->linAlg->fill(nrs->cds->fieldOffsetSum, 0.0, nrs->cds->o_S);
+    }
+
     nrs->restartFromFile(restartFile); 
  
     double startTime;
     platform->options.getArgs("START TIME", startTime);
  
-    nrs->copyToNek(0.0, 0);
+    nrs->copyToNek(0.0, 0, true);
     nek::userchk();
  
     auto err = nek::ptr<double>("errors");
@@ -758,9 +791,43 @@ void ciCheckpointing(nrs_t *nrs)
     nrs->checkpointWriter.reset();
   };
 
-  run("NEK", "ethier0.f00000");
-  run("ADIOS", "ethier.bp");
-  run("ADIOS", "ethier.bp+int", true);
+  auto destroyMesh = [&]() {
+    auto mesh = (nrs->cht) ? nrs->cds->mesh[0] : nrs->mesh;
+
+    platform->linAlg->fill(mesh->Nlocal, -0.12, mesh->o_x);
+    platform->linAlg->fill(mesh->Nlocal, -0.12, mesh->o_y);
+    platform->linAlg->fill(mesh->Nlocal, -0.12, mesh->o_z);
+
+    auto [x, y, z] = mesh->xyzHost(); // device to host
+    for (int i = 0; i < mesh->Nlocal; i++) {
+      nekData.xm1[i] = x[i];
+      nekData.ym1[i] = y[i];
+      nekData.zm1[i] = z[i];
+    }
+  };
+
+  if (ciMode==23) {
+    run("NEK", "ethier0.f00000");
+
+/*  
+    run("NEK", "ethier0.f00000");
+    run("NEK", "ethier0.f00001+U+P+T+S");
+
+    destroyMesh(); // force loading mesh from restart
+    run("NEK", "ethier0.f00000+X,ethier0.f00001+U+P+S", true);
+*/  
+
+    run("ADIOS", "ethier.bp");
+    run("ADIOS", "ethier.bp+int", true);
+  }
+  if (ciMode==25) {
+    platform->options.setArgs("MESH REFINEMENT SCHEDULE", "0"); // TODO
+    run("NEK", "ethierRefine0.f00000");
+    //platform->options.setArgs("MESH REFINEMENT SCHEDULE", "0");
+    //run("NEK", "ref22.fld",true);
+    platform->options.setArgs("MESH REFINEMENT SCHEDULE", "4");
+    run("NEK", "ref0.fld",true);
+  }
 }
 
 void ciTestDistance(nrs_t *nrs)
@@ -979,7 +1046,7 @@ void ciTestErrors(nrs_t *nrs,
     return; // don't run the rest of the tests
   }
 
-  if (tstep == 1 && ciMode != 7 && ciMode != 13 && ciMode != 8) {
+  if (tstep == 1 && ciMode != 7 && ciMode != 13 && ciMode != 8 && ciMode != 24) { // TODO
     const auto NiterP = nrs->pSolver->Niter();
 
     int expectedNiterP = 7; 
@@ -1372,7 +1439,17 @@ void ciTestErrors(nrs_t *nrs,
     prTest = err[1] < 8e-4;
     break;
   }
-
+  case 24:
+  {
+    velIterTest = true; //abs(NiterU - 14) < 2; // TODO
+    s1Test = abs((err[2] - 5.42E-12) / err[2]) < EPS;
+    s2Test = abs((err[3] - 6.30E-12) / err[3]) < EPS;
+    pIterTest = true; //abs(NiterP - 6) < 2;
+    vxTest = abs((err[0] - 2.77E-10) / err[0]) < EPS;
+    prTest = abs((err[1] - 7.14E-10) / err[1]) < EPS;
+    break;
+  }
+ 
   }
 
   if (nrs->timeStepConverged) {

--- a/examples/ethier/ci.inc
+++ b/examples/ethier/ci.inc
@@ -785,7 +785,7 @@ void ciCheckpointing(nrs_t *nrs)
   run("NEK", "ethier0.f00001+U+P+T+S");
 
   breakMeshMesh(); // force loading mesh from restart
-  run("NEK", "ethier0.f00000+X, ethier0.f00001+U+P+S", true);
+  run("NEK", "ethier0.f00000+X,ethier0.f00001+U+P+S", true);
 
   run("ADIOS", "ethier.bp");
   run("ADIOS", "ethier.bp+int", true);

--- a/examples/ethier/ethier.udf
+++ b/examples/ethier/ethier.udf
@@ -489,7 +489,7 @@ void UDF_ExecuteStep(double time, int tstep)
     }
   }
 
-  if (ciMode == 23 || ciMode == 25) {
+  if (ciMode == 23 || ciMode == 26 || ciMode == 27) {
     ciCheckpointing(nrs);
   }
 

--- a/examples/ethier/ethier.udf
+++ b/examples/ethier/ethier.udf
@@ -489,7 +489,7 @@ void UDF_ExecuteStep(double time, int tstep)
     }
   }
 
-  if (ciMode == 23) {
+  if (ciMode == 23 || ciMode == 25) {
     ciCheckpointing(nrs);
   }
 

--- a/examples/ethier/ethierRefine.par
+++ b/examples/ethier/ethierRefine.par
@@ -1,0 +1,51 @@
+[GENERAL]
+#verbose = true 
+polynomialOrder = 9
+#startFrom = "restart.fld"
+stopAt = numSteps
+numSteps = 1000
+dt = 2e-03
+timeStepper = tombo3
+checkpointControl = simulationTime 
+checkpointInterval = 0.1
+
+usr = "ethier.usr"
+oudf = "ethier.oudf"
+udf = "ethier.udf"
+
+[MESH]
+file = "ethier.re2"
+refine = 2
+#refine = 2,2
+maxelements = 2048 # 32 * 8 * 8
+
+[PRESSURE]
+residualTol = 1e-08
+
+[VELOCITY]
+boundaryTypeMap = codedFixedValue 
+residualTol = 1e-12
+rho = 1.0
+viscosity = 1/100
+
+[SCALAR00]
+boundaryTypeMap = codedFixedValue 
+residualTol = 1e-12
+rho = 1.0
+diffusivity = 1/100
+
+[SCALAR01]
+boundaryTypeMap = codedFixedGradient  
+residualTol = 1e-12
+rho = 1.0
+diffusivity = 1/100
+
+[CASEDATA]
+P_U0 = 0.5
+P_V0 = 0.1
+P_W0 = 0.2
+P_A0 = 0.025
+P_D0 = 0.5
+P_OMEGA = 15.0
+P_AMP = 1.5
+

--- a/src/core/io/iofld.hpp
+++ b/src/core/io/iofld.hpp
@@ -63,6 +63,7 @@ public:
   bool outputMesh = false;
   bool redistribute = true;
   bool pointInterpolation = false;
+  std::vector<int> refineSchedule = {};
 
   void writeAttribute(const std::string& key_, const std::string& val)
   {
@@ -100,6 +101,16 @@ public:
     if (key == "interpolate") {
       pointInterpolation = (val == "true") ? true : false;
       if (pointInterpolation) redistribute = false; 
+    }
+    if (key == "refine") {
+      refineSchedule.clear();
+      std::vector<std::string> list = serializeString(val, ',');
+      for (auto &entry : list) {
+        int ncut = std::stoi(entry);
+        if (ncut > 0) {
+          refineSchedule.push_back(ncut);
+        }
+      }
     }
   }
 

--- a/src/core/io/iofldAdios.cpp
+++ b/src/core/io/iofldAdios.cpp
@@ -704,6 +704,8 @@ size_t iofldAdios::read()
       return exists;
    };
 
+  nekrsCheck(refineSchedule.size() > 0, MPI_COMM_SELF, EXIT_FAILURE, "%s\n", "read attribute refine not supported!");
+
   // first allocate then get variable to ensure deferred pointer to memPool remains valid
   for (int pass = 0; pass < 2; pass++) {
     const auto allocateOnly = (pass == 0) ? true : false;

--- a/src/core/io/iofldNek.cpp
+++ b/src/core/io/iofldNek.cpp
@@ -143,7 +143,7 @@ size_t iofldNek::read()
 {
   nekrsCheck(pointInterpolation, MPI_COMM_SELF, EXIT_FAILURE, "%s\n", "read attribute interpolate not supported!");
 
-  nek::readFld(fldData);
+  nek::readFld(fldData, refineSchedule);
 
   if (auto time = inquireVariable<double>("time")) {
     time->get() = fldData.time;

--- a/src/core/io/par.cpp
+++ b/src/core/io/par.cpp
@@ -190,6 +190,7 @@ static std::vector<std::string> meshKeys = {
     {"connectivitytol"},
     {"boundaryidmapV"},
     {"boundaryidmap"},
+    {"refine"},
 };
 
 static std::vector<std::string> velocityKeys = {
@@ -2094,6 +2095,22 @@ void parseMeshSection(const int rank, setupAide &options, inipp::Ini *ini)
     std::string meshFile;
     if (ini->extract("mesh", "file", meshFile)) {
       options.setArgs("MESH FILE", meshFile);
+    }
+
+    std::string p_refineSchedule;
+    if (ini->extract("mesh", "refine", p_refineSchedule)) {
+      options.setArgs("MESH REFINEMENT SCHEDULE", p_refineSchedule);
+
+      int ncut = 1;
+      for (auto &&s : serializeString(p_refineSchedule, ',')) {
+        ncut *= std::stoi(s);
+      }
+      if (ncut > 1) {
+        int ndim = 3;
+        int scale = static_cast<int>(std::pow(ncut, ndim));
+        options.setArgs("MESH REFINEMENT NCUT", std::to_string(ncut));
+        options.setArgs("MESH REFINEMENT SCALE", std::to_string(scale));
+      }
     }
 
     parseLinearSolver(rank, options, ini, "mesh");

--- a/src/core/io/par.cpp
+++ b/src/core/io/par.cpp
@@ -136,6 +136,8 @@ static std::vector<std::string> generalKeys = {
     {"checkpointControl"},
     {"writeInterval"},
     {"checkpointInterval"},
+    {"checkpointRefineRead"},
+//  {"checkpointRefineWrite"}, // future work
     {"constFlowRate"},
     {"verbose"},
     {"variableDT"},
@@ -190,6 +192,7 @@ static std::vector<std::string> meshKeys = {
     {"connectivitytol"},
     {"boundaryidmapV"},
     {"boundaryidmap"},
+    {"maxElements"},
     {"refine"},
 };
 
@@ -2068,6 +2071,12 @@ void parseGeneralSection(const int rank, setupAide &options, inipp::Ini *ini)
     }
   }
 
+  std::string checkpointRefineRead;
+  options.setArgs("CHECKPOINT REFINE READ SCHEDULE", "0");
+  if (!ini->extract("general", "checkpointrefineread", checkpointRefineRead)) {
+    options.setArgs("CHECKPOINT REFINE READ SCHEDULE", checkpointRefineRead);
+  }
+
   bool dealiasing = true;
   if (ini->extract("general", "dealiasing", dealiasing)) {
     if (dealiasing) {
@@ -2095,6 +2104,11 @@ void parseMeshSection(const int rank, setupAide &options, inipp::Ini *ini)
     std::string meshFile;
     if (ini->extract("mesh", "file", meshFile)) {
       options.setArgs("MESH FILE", meshFile);
+    }
+
+    int maxElements;
+    if (ini->extract("mesh", "maxelements", maxElements)) {
+      options.setArgs("MAX NUMBER OF ELEMENTS", std::to_string(maxElements));
     }
 
     std::string p_refineSchedule;

--- a/src/elliptic/registerEllipticKernels.cpp
+++ b/src/elliptic/registerEllipticKernels.cpp
@@ -147,6 +147,14 @@ void registerEllipticKernels(std::string section, int poissonEquation)
   int nelgt, nelgv;
   const std::string meshFile = platform->options.getArgs("MESH FILE");
   re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+  {
+    int nscale = 1;
+    platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+    if (nscale > 1) {
+      nelgt *= nscale;
+      nelgv *= nscale;
+    }
+  }
   const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
   bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");
   const int verbosity = verbose ? 2 : 1;

--- a/src/elliptic/registerEllipticPreconditionerKernels.cpp
+++ b/src/elliptic/registerEllipticPreconditionerKernels.cpp
@@ -1,7 +1,7 @@
 #include <compileKernels.hpp>
 #include "benchmarkFDM.hpp"
 #include "benchmarkAx.hpp"
-#include "ellipticPrecon.h" 
+#include "ellipticPrecon.h"
 
 #include "re2Reader.hpp"
 
@@ -34,6 +34,14 @@ void registerAxKernels(const std::string &section, int N, int poissonEquation)
   int nelgt, nelgv;
   const std::string meshFile = platform->options.getArgs("MESH FILE");
   re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+  {
+    int nscale = 1;
+    platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+    if (nscale > 1) {
+      nelgt *= nscale;
+      nelgv *= nscale;
+    }
+  }
   const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
   occa::properties AxKernelInfo = kernelInfo;
@@ -166,7 +174,7 @@ void registerSchwarzKernels(const std::string &section, int N)
 
   const bool serial = platform->serial;
   const std::string oklpath = getenv("NEKRS_KERNEL_DIR") + std::string("/elliptic/");
- 
+
   std::string fileName, kernelName;
   const std::string extension = serial ? ".c" : ".okl";
 
@@ -187,6 +195,14 @@ void registerSchwarzKernels(const std::string &section, int N)
     int nelgt, nelgv;
     const std::string meshFile = platform->options.getArgs("MESH FILE");
     re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+    {
+      int nscale = 1;
+      platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
     const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
     bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");
@@ -270,7 +286,7 @@ void registerMultigridLevelKernels(const std::string &section, int Nf, int N, in
 
   if (N == 1) {
     if (  platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE", "TRUE") &&
-         !platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE AND SMOOTH", "TRUE") ) { 
+         !platform->options.compareArgs(optionsPrefix + "MULTIGRID COARSE SOLVE AND SMOOTH", "TRUE") ) {
       return;
     }
   }

--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -212,6 +212,14 @@ void setup(MPI_Comm commg_in,
   {
     int nelgt, nelgv;
     re2::nelg(platform->options.getArgs("MESH FILE"), nelgt, nelgv, comm);
+    {
+      int nscale = 1;
+      options->getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
     nekrsCheck(size > nelgv, platform->comm.mpiComm, EXIT_FAILURE, "%s\n", "MPI tasks > number of elements!");
   }
 

--- a/src/nekInterface/Makefile
+++ b/src/nekInterface/Makefile
@@ -9,14 +9,17 @@ USR_LFLAGS_:=$(shell echo $(USR_LFLAGS) | sed -E "s@-L$(left)[^ ]+$(right)@-Wl,-
 
 NI_LDFLAGS = $(LDFLAGS) -Wl,-rpath,. -L$(OBJDIR) -lnek5000 -ldl $(USR_LFLAGS_)
 
-$(OBJDIR)/nekInterface.o: $(NEKRS_NEKINTERFACE_DIR)/nekInterface.f $(LIB) 
-	$(FC) -c $(FL2) $< -o $@ 
+$(OBJDIR)/nekInterface.o: $(NEKRS_NEKINTERFACE_DIR)/nekInterface.f $(LIB)
+	$(FC) -c $(FL2) $< -o $@
+
+$(OBJDIR)/nekRefine.o: $(NEKRS_NEKINTERFACE_DIR)/nekRefine.f $(LIB)
+	$(FC) -c $(FL2) $< -o $@
 
 libnekInterface: lib$(CASENAME).so
 
-lib$(CASENAME).so: $(LIB) $(USRF) $(OBJDIR)/nekInterface.o
-	$(FC) $(FL2) -shared -o lib$(CASENAME).so $(USRF) $(OBJDIR)/nekInterface.o $(NI_LDFLAGS)
+lib$(CASENAME).so: $(LIB) $(USRF) $(OBJDIR)/nekInterface.o $(OBJDIR)/nekRefine.o
+	$(FC) $(FL2) -shared -o lib$(CASENAME).so $(USRF) $(OBJDIR)/nekInterface.o $(OBJDIR)/nekRefine.o $(NI_LDFLAGS)
 
 #.NOTPARALLEL:
 
-.PHONY: libnekInterface 
+.PHONY: libnekInterface

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -1323,16 +1323,12 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine nekf_readfld(xm1_,ym1_,zm1_,vx_,vy_,vz_,pm1_,t_,ps_
-     $                       ,refine, refineSize);
+      subroutine nekf_readfld(xm1_,ym1_,zm1_,vx_,vy_,vz_,pm1_,t_,ps_)
 
       include 'mpif.h'
       include 'SIZE'
       include 'TOTAL'
       include 'RESTART'
-
-      integer refineSize
-      integer refine(refineSize)
 
       real xm1_(lx1,ly1,lz1,*), ym1_(lx1,ly1,lz1,*), zm1_(lx1,ly1,lz1,*)
       real vx_ (lx1,ly1,lz1,*), vy_ (lx1,ly1,lz1,*), vz_ (lx1,ly1,lz1,*)
@@ -1352,20 +1348,6 @@ c-----------------------------------------------------------------------
 
       integer   disp_unit
       integer*8 win_size
-
-      logical ifremap
-
-      if (np.gt.1) then
-      do iref=1,refineSize
-        ncut = refine(iref)
-        nblk = ncut**ldim
-        do i=1,nelr                       ! go through elem in file
-          iegr = er(i)                    ! global id of thie elem
-          iegnr = ie_map_c2f(iegr,nblk)   ! map to the global id of the refined elem
-          er(i) = iegnr                   ! put it back to the list
-        enddo
-      enddo
-      endif
 
 #ifdef MPI
       if (ifcrrs) then
@@ -1439,72 +1421,6 @@ c-----------------------------------------------------------------------
         if(nid.eq.pid0r) call byte_close(ierr)
       endif
       call err_chk(ierr,'Error closing restart file, in mfi.$')
-
-      ncut_total = 1
-      do iref=1,refineSize
-        ncut_total = ncut_total * refine(iref)
-      enddo
-      nblk_total = ncut_total**ldim
-
-      ! TODO check devisible and such
-      if (np.gt.1) then
-        nelt0 = nelt
-        do iref=refineSize,1,-1 ! reverse copy
-          ncut = refine(iref)
-          nblk = ncut**ldim
-          nelt0 = nelt0 / nblk
-
-          if (ifgetxr) then
-            call h_refine_copy(xm1_,nelt0,ncut)
-            call h_refine_copy(ym1_,nelt0,ncut)
-            call h_refine_copy(zm1_,nelt0,ncut)
-          endif
-          if (ifgetur) then
-            call h_refine_copy(vx_,nelt0,ncut)
-            call h_refine_copy(vy_,nelt0,ncut)
-            call h_refine_copy(vz_,nelt0,ncut)
-          endif
-          if (ifgetpr) then
-            call h_refine_copy(pm1_,nelt0,ncut)
-          endif
-          if (ifgettr) then
-            call h_refine_copy(t_,nelt0,ncut)
-          endif
-          do k=1,npsr
-            call h_refine_copy(ps_(1,1,1,1,k),nelt0,ncut)
-          enddo
-        enddo
-      endif
-      ! TODO check nelt0 * nelt / nblk_total
-
-      nelt0 = nelt / nblk_total
-      do iref=1,refineSize
-        ! TODO, copy data to avoid gap
-        ! TODO: print
-        ncut = refine(iref)
-        nblk = ncut**ldim
-        if (ifgetxr) then
-          call h_refine_fld(xm1_,nelt0,ncut)
-          call h_refine_fld(ym1_,nelt0,ncut)
-          call h_refine_fld(zm1_,nelt0,ncut)
-        endif
-        if (ifgetur) then
-          call h_refine_fld(vx_,nelt0,ncut)
-          call h_refine_fld(vy_,nelt0,ncut)
-          call h_refine_fld(vz_,nelt0,ncut)
-        endif
-        if (ifgetpr) then
-          call h_refine_fld(pm1_,nelt0,ncut)
-        endif
-        if (ifgettr) then
-          call h_refine_fld(t_,nelt0,ncut)
-        endif
-        do k=1,npsr
-          call h_refine_fld(ps_(1,1,1,1,k),nelt0,ncut)
-        enddo
-        nelt0 = nelt0 * nblk
-      enddo
-      ! TODO check nelt0 = nelt
 
 #ifdef MPI
       if (ifcrrs) then

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -197,11 +197,13 @@ c-----------------------------------------------------------------------
       endif
 #endif
 
+      call ifill(boundaryID, -1, 6*lelv)
+      call ifill(boundaryIDt, -1, 6*lelt)
+
       ifld_bId = 2
       if(ifflow) ifld_bId = 1
       do iel = 1,nelv
       do ifc = 1,2*ndim
-         boundaryID(ifc,iel) = -1
          if(bc(5,ifc,iel,ifld_bId).gt.0) then
            boundaryID(ifc,iel) = bc(5,ifc,iel,ifld_bId)
            idx = ibsearch(bIDMap, bIDMapSize, bc(5,ifc,iel,ifld_bId))
@@ -216,7 +218,6 @@ c-----------------------------------------------------------------------
       if(nelgt.ne.nelgv) then 
         do iel = 1,nelt
         do ifc = 1,2*ndim
-         boundaryIDt(ifc,iel) = -1
          if(bc(5,ifc,iel,2).gt.0) then
            boundaryIDt(ifc,iel) = bc(5,ifc,iel,2)
            idx = ibsearch(bIDtMap, bIDtMapSize, bc(5,ifc,iel,2))

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -111,7 +111,7 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine nekf_setup(ifflow_in, 
+      subroutine nekf_setup(ifflow_in, refine, refineSize,
      $                      bIDMap, bIDMapSize, bIDtMap, bIDtMapSize,
      $                      npscal_in, idpss_in, p32, mpart, contol,
      $                      rho, mue, rhoCp, lambda, stsform) 
@@ -120,6 +120,9 @@ c-----------------------------------------------------------------------
       include 'TOTAL'
       include 'DOMAIN'
       include 'NEKINTF'
+
+      integer refineSize
+      integer refine(refineSize)
 
       integer bIDMapSize
       integer bIDtMapSize
@@ -250,6 +253,10 @@ c-----------------------------------------------------------------------
 
       if(nio.eq.0) write(6,*) 'call usrdat2'
       etime1 = dnekclock_sync()
+      do iref=1,refineSize
+        call usrdat2_oct(refine(iref))
+      enddo
+
       call usrdat2
       etime2 = dnekclock_sync()
       if(nio.eq.0) write(6,998) ' done :: usrdat2', etime2-etime1

--- a/src/nekInterface/nekInterface.f
+++ b/src/nekInterface/nekInterface.f
@@ -1385,6 +1385,7 @@ c-----------------------------------------------------------------------
      $                        commrs,rsH,ierr)
 
           if (ierr .ne. 0 ) call exitti('MPI_Win_allocate failed!$',0)
+          call rzero(wk,lwk) ! avoid un-initialized values, FE_INVALID, in h_refine
         endif
       endif
 #endif

--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -867,16 +867,16 @@ void buildNekInterface(int ldimt, int N, int np, setupAide &options)
       const std::string meshFile = options.getArgs("MESH FILE");
 
       re2::nelg(meshFile, nelgt, nelgv, MPI_COMM_SELF);
+      int lelt = (nelgt / np) + 3;
       {
         int nscale = 1;
         platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
         if (nscale > 1) {
           nelgt *= nscale;
           nelgv *= nscale;
+          lelt *= nscale;
         }
       }
-
-      int lelt = (nelgt / np) + 3;
       if (lelt > nelgt) {
         lelt = nelgt;
       }

--- a/src/nekInterface/nekInterfaceAdapter.hpp
+++ b/src/nekInterface/nekInterfaceAdapter.hpp
@@ -113,7 +113,7 @@ struct fldData {
 };
 
 fldData openFld(const std::string& filename, std::vector<std::string>& _availableVariables);
-void readFld(fldData& data);
+void readFld(fldData& data, std::vector<int> refineSchedule = {});
 void writeFld(const std::string& filename,
               const fldData& data,
               bool FP64 = false,

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -233,6 +233,8 @@ c                                   ncut = 4 --> 64x number of elements
       lxyc = 2**ldim
       nvrt = ncut+1
 
+      if (nio.eq.0) write(6,12) nblk
+ 12      format('h-refine: split each element into',I12)
 c     CHECK limit sizes 
 
       call lim_chk(nblk,mxnew,'nblk ','mxnew',' h_refine ')

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -1,0 +1,344 @@
+c-----------------------------------------------------------------------
+      subroutine usrdat2_oct(ncut) ! interface to oct-refine code
+
+c     Note that lelt and lelg need to be LARGE enough
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      parameter(lxyz=lx1*ly1*lz1)
+      common /c_is1/ glo_num(lxyz*lelt)
+      integer*8 glo_num
+
+      ncut_o = ncut
+
+      call h_refine(glo_num,ncut_o)
+
+c     call outpost(xm1,ym1,zm1,pr,t,'   ')
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine interp_mat(jmat,zo,no,zi,ni,s,t)
+      real jmat(no,ni),zo(no),zi(ni),s(ni),t(ni)
+
+      call rone(s,ni)
+      do i=1,ni                ! Compute denominators ("alpha_i")
+         do j=1,i-1
+            s(i) = s(i)*(zi(i)-zi(j))
+         enddo
+         do j=i+1,ni
+            s(i) = s(i)*(zi(i)-zi(j))
+         enddo
+      enddo
+
+      do j=1,ni
+         a_j = 1./s(j)
+         do i=1,no
+            jmat(i,j) = a_j
+         enddo
+      enddo
+
+      call rone(s,ni)
+      call rone(t,ni)
+      do i=1,no
+         x=zo(i)
+         do j=2,ni
+            jm   = ni+1-j
+            s(j) = s(j-1 )*(x-zi(j-1))
+            t(jm)= t(jm+1)*(x-zi(jm+1))
+         enddo
+         do j=1,ni
+            jmat(i,j) = jmat(i,j)*s(j)*t(j)
+         enddo
+      enddo
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine get_rst_m1(xb,yb,zb,ncut,x1,y1,z1,pc,pt)
+
+c       call get_rst_m1(x0,y0,z0,ncut
+c    $                 ,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e),pc,pt)
+
+      include 'SIZE'
+      include 'TOTAL'
+
+      real xb(lx1*ly1*lz1,ncut*ncut*ncut)
+     $    ,yb(lx1*ly1*lz1,ncut*ncut*ncut)
+     $    ,zb(lx1*ly1*lz1,ncut*ncut*ncut)
+
+      real x1(lx1*ly1*lz1),y1(lx1*ly1*lz1),z1(lx1*ly1*lz1)
+      real pc(lx1*lx1,ncut) ! Interpolation matrix
+      real pt(lx1*lx1,ncut) ! Interpolation matrix
+
+      common /qtmp0/ z_out(lx1),wk(lx1*lx1),wk2(lx1*lx1)
+
+c     if (pc(1,1).eq.0) then  ! Recompute interpolation matrices
+      if (lx1.gt.0)     then  ! Recompute interpolation matrices
+        dr = 2./ncut
+        do k=1,ncut
+          r0 = -1. + (k-1)*dr
+          do i=1,lx1
+            z_out(i) = r0 + dr*(zgm1(i,1)+1)/2.
+          enddo
+          call interp_mat(pc(1,k),z_out,lx1,zgm1,lx1,wk,wk2)
+          call transpose (pt(1,k),lx1,pc(1,k),lx1)
+        enddo
+      endif
+
+      if (ldim.eq.3) then
+
+       lc=0
+       do kc=1,ncut
+       do jc=1,ncut
+       do ic=1,ncut
+          lc=lc+1
+          call tensr3(xb(1,lc),lx1,x1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(yb(1,lc),lx1,y1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(zb(1,lc),lx1,z1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+       enddo
+       enddo
+       enddo
+
+      else ! 2D
+
+       lc=0
+       do jc=1,ncut
+       do ic=1,ncut
+          lc=lc+1
+          call tensr3(xb(1,lc),lx1,x1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+          call tensr3(yb(1,lc),lx1,y1,lx1,pc(1,ic),pt(1,jc),pt(1,kc),wk)
+       enddo
+       enddo
+
+      endif
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine elcopy(en,e)
+      include 'SIZE'
+      include 'TOTAL'
+
+c     ADD MORE ITEMS, as needed
+
+      integer e,en,eg
+
+      lxyz = lx1*ly1*lz1
+
+      call copy(xm1(1,1,1,en),xm1(1,1,1,e),lxyz)
+      call copy(ym1(1,1,1,en),ym1(1,1,1,e),lxyz)
+      call copy(zm1(1,1,1,en),zm1(1,1,1,e),lxyz)
+
+      do kf=0,ldimt1
+         call chcopy(cbc(1,en,kf),cbc(1,e,kf),18)
+         call copy  (bc(1,1,en,kf),bc(1,1,e,kf),30)
+      enddo
+      call icopy (boundaryID(1,en),boundaryID(1,e),6)
+      call icopy (boundaryIDt(1,en),boundaryIDt(1,e),6)
+
+      call copy  (curve(1,1,en),curve(1,1,e),72)
+      call chcopy(ccurve(1,en),ccurve(1,e),12)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine nek_init_2
+c
+      include 'SIZE'
+      include 'TOTAL'
+      include 'DOMAIN'
+c
+      include 'OPCTR'
+      include 'CTIMER'
+
+      real kwave2
+      logical ifemati
+
+      real rtest
+      integer itest
+      integer*8 itest8
+      character ctest
+      logical ltest 
+
+      common /c_is1/ glo_num(lx1 * ly1 * lz1, lelt)
+      common /ivrtx/ vertex((2 ** ldim) * lelt)
+      integer*8 glo_num, ngv
+      integer*8 vertex
+
+      if (nio.eq.0) then
+         write(6,12) 'nelgt/nelgv/lelt:',nelgt,nelgv,lelt
+         write(6,12) 'lx1/lx2/lx3/lxd: ',lx1,lx2,lx3,lxd
+ 12      format(1X,A,4I12)
+         write(6,*)
+      endif
+
+      instep=1             ! Check for zero steps
+      if (nsteps.eq.0 .and. fintim.eq.0.) instep=0
+
+      igeom = 2
+      call setup_topo      ! Setup domain topology  
+
+      if (ifmvbd) call setup_mesh_dssum ! Set mesh dssum (needs geom)
+
+      return
+      end
+c-----------------------------------------------------------------------
+      subroutine h_refine(glo_num,ncut)
+
+c     Here we do an "ncut" refine:  ncut = 2 --> oct-refine (8x number of elements)
+c                                   ncut = 3 --> 27x number of elements
+c                                   ncut = 4 --> 64x number of elements
+
+      include 'SIZE'
+      include 'TOTAL'
+      include 'SCRCT'  ! For xyz() array
+
+      integer*8 glo_num(ncut+1,ncut+1,ncut*(ldim-2)+1,lelt)
+      integer e,eg,egn,el,en,er,es,et
+
+      parameter(lxyz=lx1*ly1*lz1,mxnew=500)
+      common /qcrmg/ x0(lxyz,mxnew),y0(lxyz,mxnew),z0(lxyz,mxnew)
+     $             , pc(lx1*lx1,mxnew),pt(lx1*lx1,mxnew)
+      real pc,pt
+
+      common /ivrtx/ vertex ((2**ldim),lelt)
+      integer*8 vertex
+      integer*8 ngv
+
+      integer ibuf(2)
+
+      integer isym2pre(8)   ! Symmetric-to-prenek vertex ordering
+      save    isym2pre
+      data    isym2pre / 1 , 2 , 4 , 3 , 5 , 6 , 8 , 7 /
+
+      nblk = ncut**ldim
+      nnew = nblk - 1
+      lxyc = 2**ldim
+      nvrt = ncut+1
+
+c     CHECK limit sizes 
+
+      call lim_chk(nblk,mxnew,'nblk ','mxnew',' h_refine ')
+
+      nelt_new = nblk*nelt+1 ! +1 for temporary storage
+      call lim_chk(nelt_new,lelt,'n_new','lelt ',' h_refine ')
+
+      nelgt_new = nblk*nelgt
+      call lim_chk(nelgt_new,lelg,'ngnew','lelg ',' h_refine ')
+
+      call rzero(pc,lx1*lx1)
+
+      call set_vert(glo_num,ngv,nvrt,nelt,vertex,.true.) ! Get new vertex set
+
+#if defined(DPROCMAP)
+      call dProcMapClearCache()
+#endif
+
+      do e=nelt,1,-1  ! REPLICATE EACH ELEMENT, working backward
+
+        eg = lglel(e)
+
+        call elcopy(lelt,e) ! Save current element
+
+        call get_rst_m1(x0,y0,z0,ncut
+     $                 ,xm1(1,1,1,e),ym1(1,1,1,e),zm1(1,1,1,e),pc,pt)
+
+
+        el = 0
+        en = nblk*(e -1)
+        egn= nblk*(eg-1)
+
+        net=ncut
+        if (ldim.eq.2) net=1
+        do et=1,net          ! ncut^ldim reps
+        do es=1,ncut
+        do er=1,ncut
+
+          el = el+1
+          en = en+1
+          egn= egn+1
+
+          call elcopy(en,lelt) ! Copy saved element e to en
+
+#if defined(DPROCMAP)
+          lglel(en) = egn
+          ibuf(1) = en
+          ibuf(2) = nid
+          call dProcmapPut(ibuf,2,0,eg)
+#else
+          lglel(en)  = egn
+          gllel(egn) = en      ! THIS PART MUST BE FIXED for scalability !
+          gllnid(eg) = nid
+#endif
+
+          call copy(xm1(1,1,1,en),x0(1,el),lxyz)
+          call copy(ym1(1,1,1,en),y0(1,el),lxyz)
+          call copy(zm1(1,1,1,en),z0(1,el),lxyz)
+
+c         Note - we need to update xc,yc,zc
+c         Note - we also should extract midside nodes.
+
+          k0=1 + (et-1)
+          j0=1 + (es-1)
+          i0=1 + (er-1)
+
+          nk = 1
+          if (ldim.eq.2) nk=0
+
+          lc = 0
+          do kc=0,nk
+          do jc=0,1
+          do ic=0,1
+             lc=lc+1
+             vertex(lc,en)=glo_num(i0+ic,j0+jc,k0+kc,e)
+
+             ii = 1 + ic*(lx1-1)
+             jj = 1 + jc*(ly1-1)
+             kk = 1 + kc*(lz1-1)
+             ipre=isym2pre(lc)
+             xc(ipre,en) = xm1(ii,jj,kk,en)
+             yc(ipre,en) = ym1(ii,jj,kk,en)
+             zc(ipre,en) = zm1(ii,jj,kk,en)
+
+             xyz(1,ipre,en)=xc(ipre,en)
+             xyz(2,ipre,en)=yc(ipre,en)
+             if (ldim.eq.3) xyz(3,ipre,en)=zc(ipre,en)
+
+          enddo
+          enddo
+          enddo
+
+          do kf=0,nfield
+              if (er.gt.1)    cbc(4,en,kf)='E  '  ! r-boundaries (face=4,2)
+              if (er.lt.ncut) cbc(2,en,kf)='E  '
+              if (es.gt.1)    cbc(1,en,kf)='E  '  ! s-boundaries (face=1,3)
+              if (es.lt.ncut) cbc(3,en,kf)='E  '
+              if (ldim.eq.3) then
+                 if (et.gt.1)    cbc(5,en,kf)='E  '  ! t-boundaries (face=5,6)
+                 if (et.lt.ncut) cbc(6,en,kf)='E  '
+              endif
+          enddo
+c         NOW, we have a periodicty problem to resolve...
+c         I think, however, that we already have the correct vertex topology
+              
+        enddo
+        enddo
+        enddo
+
+      enddo
+
+      nelt  = nblk*nelt
+      nelv  = nblk*nelv
+      nelgt = nblk*nelgt
+      nelgv = nblk*nelgv
+
+      do ifld=0,nfield
+         nelfld(ifld)=nblk*nelfld(ifld)
+      enddo
+
+      call nek_init_2  ! Reset some of the key arrays, etc.
+
+      return
+      end
+c-----------------------------------------------------------------------

--- a/src/nekInterface/nekRefine.f
+++ b/src/nekInterface/nekRefine.f
@@ -143,6 +143,22 @@ c     ADD MORE ITEMS, as needed
       return
       end
 c-----------------------------------------------------------------------
+      subroutine fczero(f,e)
+      include 'SIZE'
+      include 'TOTAL'
+
+      integer f,e
+
+      do kf=0,nfield
+          cbc(f,e,kf)='E  '
+          call rzero(bc(1,f,e,kf),5)
+      enddo
+      boundaryID(f,e)=0
+      boundaryIDt(f,e)=0
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine nek_init_2
 c
       include 'SIZE'
@@ -309,16 +325,15 @@ c         Note - we also should extract midside nodes.
           enddo
           enddo
 
-          do kf=0,nfield
-              if (er.gt.1)    cbc(4,en,kf)='E  '  ! r-boundaries (face=4,2)
-              if (er.lt.ncut) cbc(2,en,kf)='E  '
-              if (es.gt.1)    cbc(1,en,kf)='E  '  ! s-boundaries (face=1,3)
-              if (es.lt.ncut) cbc(3,en,kf)='E  '
-              if (ldim.eq.3) then
-                 if (et.gt.1)    cbc(5,en,kf)='E  '  ! t-boundaries (face=5,6)
-                 if (et.lt.ncut) cbc(6,en,kf)='E  '
-              endif
-          enddo
+          if (er.gt.1)    call fczero(4,en)  ! r-boundaries (face=4,2)
+          if (er.lt.ncut) call fczero(2,en)
+          if (es.gt.1)    call fczero(1,en)  ! s-boundaries (face=1,3)
+          if (es.lt.ncut) call fczero(3,en)
+          if (ldim.eq.3) then
+             if (et.gt.1)    call fczero(5,en)  ! t-boundaries (face=5,6)
+             if (et.lt.ncut) call fczero(6,en)
+          endif
+
 c         NOW, we have a periodicty problem to resolve...
 c         I think, however, that we already have the correct vertex topology
               

--- a/src/nrs/nrs.cpp
+++ b/src/nrs/nrs.cpp
@@ -919,6 +919,19 @@ void nrs_t::restartFromFile(const std::string &restartStr)
     return found;
   }();
 
+  auto hRefine = [&]() {
+    auto it = std::find_if(options.begin(), options.end(), [](const std::string &s) {
+      return s.find("refine") != std::string::npos;
+    });
+
+    std::string val;
+    if (it != options.end()) {
+      val = serializeString(*it, '=').at(1);
+      options.erase(it);
+    }
+    return val;
+  }();
+
   const auto requestedFields = [&]() {
     std::vector<std::string> flds;
     for (const auto &entry : {"x", "u", "p", "t", "s"}) {
@@ -1019,6 +1032,11 @@ void nrs_t::restartFromFile(const std::string &restartStr)
 
   if (pointInterpolation) {
     iofld->readAttribute("interpolate", "true");
+  }
+
+  if (hRefine.size()) {
+    std::replace(hRefine.begin(), hRefine.end(), ';', ',');
+    iofld->readAttribute("refine", hRefine);
   }
 
   iofld->process();

--- a/src/nrs/nrs.cpp
+++ b/src/nrs/nrs.cpp
@@ -564,6 +564,14 @@ void nrs_t::init()
     int nelgt, nelgv;
     const std::string meshFile = platform->options.getArgs("MESH FILE");
     re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+    {
+      int nscale = 1;
+      platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+      if (nscale > 1) {
+        nelgt *= nscale;
+        nelgv *= nscale;
+      }
+    }
 
     nekrsCheck(nelgt != nelgv && platform->options.compareArgs("MOVING MESH", "TRUE"),
                platform->comm.mpiComm,

--- a/src/nrs/registerNrsKernels.cpp
+++ b/src/nrs/registerNrsKernels.cpp
@@ -200,6 +200,14 @@ void registerNrsKernels(occa::properties kernelInfoBC)
       int nelgt, nelgv;
       const std::string meshFile = platform->options.getArgs("MESH FILE");
       re2::nelg(meshFile, nelgt, nelgv, platform->comm.mpiComm);
+      {
+        int nscale = 1;
+        platform->options.getArgs("MESH REFINEMENT SCALE", nscale);
+        if (nscale > 1) {
+          nelgt *= nscale;
+          nelgv *= nscale;
+        }
+      }
       const int NelemBenchmark = nelgv / platform->comm.mpiCommSize;
 
       bool verbose = platform->options.compareArgs("VERBOSE", "TRUE");


### PR DESCRIPTION
On-the-fly oct-tree mesh refinement.

- Controlled in par file. To split all elements into 8, simply put number of the segment into the par key like this:
  ```
  [GENERAL]
  refine = 2
  ```

- Support multiple refinements: The below will do two rounds of refinement with `1-> 8 -> 8*27`
  ```
  [GENERAL]
  refine = 2,3
  ``` 
 
- Supports restart from original (or other coarse) mesh controlled by the restart option `refine=a;b;c`.
  `startFrom = "r1.fld+refine=2"` refines the fields from the checkpoint file.
  `startFrom = "r1.fld+refine=2;3"` does twice refinement with refein=2 follows by refine=3. (order will affect element numbering matters).
  It works with other options as well such as `startFrom = "r1.fld+U+refine=2"`
  Refinement + restart doesn't support Adios for now.

- Refinement is local inside MPI rank so load imbalance (i.e., `max(nel) - max(nel) > 1`) can happen.

- See ethier example `ciMode=24,25,26,27`.

- Add `[MESH] maxElements` par key to set lelg in nek5000/SIZE, which gives more flexibility in CI test.

[![CI](https://github.com/yslan/nekRS/actions/workflows/ci.yml/badge.svg)](https://github.com/yslan/nekRS/actions/workflows/ci.yml)